### PR TITLE
Add `:skip` commands to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "SKIP_ENV_VALIDATION=1 next build",
-    "dev": "SKIP_ENV_VALIDATION=1 next dev",
+    "build": "next build",
+    "dev": "next dev",
+    "build:skip": "SKIP_ENV_VALIDATION=1 next build",
+    "dev:skip": "SKIP_ENV_VALIDATION=1 next dev",
     "postinstall": "prisma generate",
     "lint": "next lint",
     "start": "next start",


### PR DESCRIPTION
Adds `:skip` commands to `build` and `dev` to work around compatibility issues with `SKIP_ENV_VALIDATION` flag. 