### PR TITLE
Use SHA as docker image name

### DIFF
--- a/.github/workflows/dev-qa-prod.yml
+++ b/.github/workflows/dev-qa-prod.yml
@@ -135,6 +135,10 @@ jobs:
       with:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
+    - name: Set outputs
+      id: vars
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'
 
@@ -148,5 +152,5 @@ jobs:
         ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Unit)"
         ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Integration)"
         ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Coverage)"
-        gcloud artifacts docker images delete northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test --delete-tags
+        gcloud artifacts docker images delete northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/${{ steps.vars.outputs.sha_short }}-test --delete-tags
 

--- a/.github/workflows/dev-qa-prod.yml
+++ b/.github/workflows/dev-qa-prod.yml
@@ -123,3 +123,30 @@ jobs:
         export CLOUDSDK_CORE_DISABLE_PROMPTS=1
         chmod +x ./scripts/wait-for-build
         ./scripts/wait-for-build ${{ secrets.GCP_BUILD_DEPLOY_ID }} ${GITHUB_REF##*/} Deploy
+
+  cleanup:
+    name: Cleanup Test Artifacts
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v3
+    - id: 'auth'
+      uses: 'google-github-actions/auth@v1'
+      with:
+        credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v1'
+
+    - name: 'Use gcloud CLI'
+      run: 'gcloud info'
+
+    - name: 'Start Google Cloud Build trigger'
+      run: |
+        export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+        chmod +x ./scripts/wait-for-build
+        ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Unit)"
+        ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Integration)"
+        ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Coverage)"
+        gcloud artifacts docker images delete northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test --delete-tags
+

--- a/.github/workflows/feature-workflow.yml
+++ b/.github/workflows/feature-workflow.yml
@@ -114,6 +114,10 @@ jobs:
       with:
         credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
+    - name: Set outputs
+      id: vars
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'
 
@@ -127,5 +131,5 @@ jobs:
         ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Unit)"
         ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Integration)"
         ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Coverage)"
-        gcloud artifacts docker images delete northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test --delete-tags
+        gcloud artifacts docker images delete northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/${{ steps.vars.outputs.sha_short }}-test --delete-tags
 

--- a/.github/workflows/feature-workflow.yml
+++ b/.github/workflows/feature-workflow.yml
@@ -102,3 +102,30 @@ jobs:
         export CLOUDSDK_CORE_DISABLE_PROMPTS=1
         chmod +x ./scripts/wait-for-build
         ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Coverage)"
+
+  cleanup:
+    name: Cleanup Test Artifacts
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v3
+    - id: 'auth'
+      uses: 'google-github-actions/auth@v1'
+      with:
+        credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v1'
+
+    - name: 'Use gcloud CLI'
+      run: 'gcloud info'
+
+    - name: 'Start Google Cloud Build trigger'
+      run: |
+        export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+        chmod +x ./scripts/wait-for-build
+        ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Unit)"
+        ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Integration)"
+        ./scripts/wait-for-build ${{ secrets.GCP_BUILD_TEST_ID }} ${GITHUB_REF##*/} "Test (Coverage)"
+        gcloud artifacts docker images delete northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test --delete-tags
+

--- a/cloudbuild/build.yaml
+++ b/cloudbuild/build.yaml
@@ -13,13 +13,13 @@ steps:
   # Docker Build (Test container)
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker build . --tag northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$BRANCH_NAME-test -f docker/test/Dockerfile']  
+    args: ['-c', 'docker build . --tag northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test -f docker/test/Dockerfile']  
     waitFor: ['-']
 
   # Docker Push
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker push northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$BRANCH_NAME-test']
+    args: ['-c', 'docker push northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test']
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild/feature-build.yaml
+++ b/cloudbuild/feature-build.yaml
@@ -2,13 +2,13 @@ steps:
   # Docker Build (Test container)
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker build . --tag northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$BRANCH_NAME-test -f docker/test/Dockerfile']  
+    args: ['-c', 'docker build . --tag northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test -f docker/test/Dockerfile']  
     waitFor: ['-']
 
   # Docker Push
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker push northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$BRANCH_NAME-test']
+    args: ['-c', 'docker push northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test']
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild/test.yaml
+++ b/cloudbuild/test.yaml
@@ -7,5 +7,15 @@ steps:
     entrypoint: 'bash'
     args: ['-c', 'docker run --rm northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test npm run test']
 
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args:
+      - 'artifacts'
+      - 'docker'
+      - 'images'
+      - 'delete'
+      - 'northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test'
+      - '--delete-tags'
+          
+
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild/test.yaml
+++ b/cloudbuild/test.yaml
@@ -7,15 +7,5 @@ steps:
     entrypoint: 'bash'
     args: ['-c', 'docker run --rm northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test npm run test']
 
-  - name: 'gcr.io/cloud-builders/gcloud'
-    args:
-      - 'artifacts'
-      - 'docker'
-      - 'images'
-      - 'delete'
-      - 'northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test'
-      - '--delete-tags'
-          
-
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild/test.yaml
+++ b/cloudbuild/test.yaml
@@ -1,11 +1,11 @@
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker pull northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$BRANCH_NAME-test']
+    args: ['-c', 'docker pull northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test']
 
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: ['-c', 'docker run --rm northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$BRANCH_NAME-test npm run test']
+    args: ['-c', 'docker run --rm northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$SHORT_SHA-test npm run test']
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Context
Altay uncovered a bug where capital letter branch names weren't valid docker image names and caused issues in the ci/cd pipeline

## Describe your changes
docker images are named according to their commit short sha

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I verified that my code will compile by running `npm run build` 
- [ ] I have run `npm run lint` and fixed linting errors
