### PR TITLE
fixing the negative seconds ago

### DIFF
--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,8 +1,8 @@
 export const timeAgo = (inputDate: Date): string => {
   const now = new Date();
-  const diffInSeconds = Math.floor(
+  const diffInSeconds = Math.max(Math.floor(
     (now.getTime() - inputDate.getTime()) / 1000
-  );
+  ), 0);
 
   if (diffInSeconds < 60) {
     return `${diffInSeconds} ${diffInSeconds === 1 ? "second" : "seconds"} ago`;


### PR DESCRIPTION
## Context
When a new blog post is created, the time shows (-7 seconds ago), which is, how is that even possible? 
this fix rounds negative numbers to 0

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] I verified that my code will compile by running `npm run build` 
- [x] I have run `npm run lint` and fixed linting errors
