### PR TITLE
[CON-11] implement blog post deletion

### DIFF
--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -6,6 +6,7 @@ import { ProfilePicture } from "./ProfilePicture";
 import { api } from "~/utils/api";
 import { BlogPostActionsMenu } from "~/components/BlogPostActionsMenu";
 import { useSession } from "next-auth/react";
+import React from "react";
 
 interface BlogPostProps extends React.ComponentProps<"div"> {
   id: string;
@@ -45,6 +46,14 @@ export const BlogPost: React.FC<BlogPostProps> = ({
       return currUser.data.id === author;
     }
   }
+
+  const isAdmin = () => {
+    if ((currUser.data !== null) && (currUser.data !== undefined)) {
+      return currUser.data.role === "ADMIN";
+    }
+    return false;
+  }
+
   return (
     <div
       className="bg-base-150 card w-full rounded-md shadow-md shadow-slate-300"
@@ -62,7 +71,7 @@ export const BlogPost: React.FC<BlogPostProps> = ({
             </div>
           </div>
           {
-            isAuthed() && isAuthor() && <BlogPostActionsMenu id={id} author={author} title={title} content={content} />
+            ((isAuthed() && isAuthor()) || (isAuthed() && isAdmin())) && <BlogPostActionsMenu id={id} title={title} content={content} isAdmin={isAdmin()}/>
           }
         </div>
         <p className="mb-3 text-xl font-bold">{title}</p>

--- a/src/components/BlogPostActionsMenu.tsx
+++ b/src/components/BlogPostActionsMenu.tsx
@@ -1,15 +1,16 @@
 import { MenuIcon } from "~/icons/Menu";
 import { UpdateBlogPostWidget } from "~/components/update-blog-post-widget/UpdateBlogPostWidget";
 import React from "react";
+import { DeleteBlogPostWidget } from "~/components/delete-blog-post-widget/DeleteBlogPostWidget";
 
 interface BlogPostActionsProps {
   id: string;
-  author: string;
   title: string;
   content: string;
+  isAdmin: boolean;
 }
 
-export const BlogPostActionsMenu: React.FC<BlogPostActionsProps> = ({id, author, title, content}) => {
+export const BlogPostActionsMenu: React.FC<BlogPostActionsProps> = ({id, title, content, isAdmin}) => {
   return (
     <div className="self-center">
       <div className="dropdown-left dropdown rounded-md shadow-slate-300">
@@ -21,10 +22,12 @@ export const BlogPostActionsMenu: React.FC<BlogPostActionsProps> = ({id, author,
           className="dropdown-content menu rounded-box w-52 bg-base-100 p-2 shadow"
         >
           <li>
-            <UpdateBlogPostWidget id={id} author={author} title={title} content={content}/>
+            {
+              !isAdmin && <UpdateBlogPostWidget id={id} title={title} content={content}/>
+            }
           </li>
           <li>
-            <a>Delete</a>
+            <DeleteBlogPostWidget id={id} />
           </li>
         </ul>
       </div>

--- a/src/components/delete-blog-post-widget/DeleteBlogPostButton.tsx
+++ b/src/components/delete-blog-post-widget/DeleteBlogPostButton.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export const DeleteBlogPostButton: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
+  return (
+    <>
+      <div onClick={onClick}>
+        <span>
+          Delete
+        </span>
+      </div>
+    </>
+  );
+};

--- a/src/components/delete-blog-post-widget/DeleteBlogPostWidget.tsx
+++ b/src/components/delete-blog-post-widget/DeleteBlogPostWidget.tsx
@@ -1,0 +1,87 @@
+import { api } from "~/utils/api";
+import React, { FormEvent, useEffect, useState } from "react";
+import { DeleteBlogPostButton } from "~/components/delete-blog-post-widget/DeleteBlogPostButton";
+import { BlogPostInputModal } from "~/components/BlogPostInputModal";
+import { Spinner } from "~/components/Spinner";
+import { FiCheck } from "react-icons/fi";
+
+interface DeleteBlogPostWidgetProps {
+  id: string
+}
+
+export const DeleteBlogPostWidget: React.FC<DeleteBlogPostWidgetProps> = ({ id }) => {
+  const utils = api.useContext();
+
+  const deleteBlogPostMutation = api.blogPost.delete.useMutation({
+    onSuccess(data, variables, context) {
+      return utils.blogPost.get.invalidate();
+    },
+  });
+
+  const [isModalOpen, setModalOpen] = useState(false);
+  const [isSuccessful, setSuccessful] = useState(false);
+
+  useEffect(() => {
+    if (deleteBlogPostMutation.isSuccess) {
+      setSuccessful(true);
+
+      const timeoutId = setTimeout(() => {
+        setModalOpen(false);
+        setSuccessful(false);
+      }, 2000);
+
+      return () => {
+        setSuccessful(false);
+        clearTimeout(timeoutId);
+      };
+    }
+  }, [deleteBlogPostMutation.isSuccess]);
+
+  return (
+    <>
+      <DeleteBlogPostButton onClick={() => setModalOpen(true)} />
+      <BlogPostInputModal
+        action="Delete"
+        isOpen={isModalOpen}
+        onRequestClose={() => {
+          setModalOpen(false);
+        }}
+        closeDisabled={deleteBlogPostMutation.isLoading || isSuccessful}
+      >
+        {deleteBlogPostMutation.isLoading ? (
+          <div className="flex h-96 w-full items-center justify-center">
+            <Spinner size={12} />
+          </div>
+        ) : isSuccessful ? (
+          <div className="flex h-96 w-full flex-col items-center justify-center">
+            <FiCheck
+              size={"12rem"}
+              className="animate-pulse stroke-highlight-green"
+            />
+            <div className="text-lg">Successfully deleted the blog post</div>
+          </div>
+        ) : (
+          <>
+            <div className="flex h-96 items-center justify-center">
+              <div className="text-lg">Are you sure you want to delete this post?</div>
+            </div>
+            <form
+              onSubmit={(event: FormEvent<HTMLFormElement>) => {
+                event.preventDefault();
+                deleteBlogPostMutation.mutate({
+                  where: {
+                    id
+                  },
+                })
+              }}
+            >
+              <input type="submit" value="Delete"
+                     className="relative left-full -translate-x-full px-6 py-2 rounded-md bg-emerald-400 my-2 -ml-4 hover:text-white transition-colors cursor-pointer"
+              />
+            </form>
+          </>
+        )}
+      </BlogPostInputModal>
+    </>
+  );
+}

--- a/src/components/update-blog-post-widget/UpdateBlogPostWidget.tsx
+++ b/src/components/update-blog-post-widget/UpdateBlogPostWidget.tsx
@@ -8,12 +8,11 @@ import { BlogPostInputModal } from "~/components/BlogPostInputModal";
 
 interface UpdateBlogPostProps {
   id: string,
-  author: string,
   title: string,
   content: string
 }
 
-export const UpdateBlogPostWidget: React.FC<UpdateBlogPostProps> = ({id, author, title, content}) => {
+export const UpdateBlogPostWidget: React.FC<UpdateBlogPostProps> = ({id, title, content}) => {
   const utils = api.useContext();
 
   const updateBlogPostMutation = api.blogPost.update.useMutation({


### PR DESCRIPTION
## Context
Add ability to delete blog posts

## Describe your changes
Implemented delete procedure call. Did not add unit tests now due to time constraint, but tested the workflow manually by switching my local user role between CONTRIBUTOR and ADMIN

Testing:
- Contributors can delete only their authored blog posts
- Admins can delete any blog post
- Admins cannot see "Edit" option when opening the blog post actions menu (3 dots menu)

## Issue ticket number and link
https://continuus.atlassian.net/browse/CON-11

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] I verified that my code will compile by running `npm run build` 
- [x] I have run `npm run lint` and fixed linting errors
