### PR TITLE
add functionality to blog post menu actions in comment modal

### DIFF
--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -7,6 +7,7 @@ import { api } from "~/utils/api";
 import { BlogPostActionsMenu } from "~/components/BlogPostActionsMenu";
 import { useSession } from "next-auth/react";
 import React from "react";
+import { isAdmin, isAuthed, isAuthor } from "~/components/util";
 
 interface BlogPostProps extends React.ComponentProps<"div"> {
   id: string;
@@ -32,28 +33,6 @@ export const BlogPost: React.FC<BlogPostProps> = ({
 }) => {
   const currUser = api.user.currentUser.useQuery();
   const { status } = useSession();
-
-  const isAuthed = () => {
-    if (status === "authenticated") {
-      return true;
-    } else if (status === "unauthenticated") {
-      return false;
-    }
-  };
-
-  const isAuthor = () => {
-    if ((currUser.data !== null) && (currUser.data !== undefined)) {
-      return currUser.data.id === author;
-    }
-  }
-
-  const isAdmin = () => {
-    if ((currUser.data !== null) && (currUser.data !== undefined)) {
-      return currUser.data.role === "ADMIN";
-    }
-    return false;
-  }
-
   return (
     <div
       className="bg-base-150 card w-full rounded-md shadow-md shadow-slate-300"
@@ -71,7 +50,9 @@ export const BlogPost: React.FC<BlogPostProps> = ({
             </div>
           </div>
           {
-            ((isAuthed() && isAuthor()) || (isAuthed() && isAdmin())) && <BlogPostActionsMenu id={id} title={title} content={content} isAdmin={isAdmin()}/>
+            ((currUser.data !== null) && (currUser.data !== undefined)) &&
+            ((isAuthed(status) && isAuthor(currUser.data, author)) || (isAuthed(status) && isAdmin(currUser.data))) &&
+              <BlogPostActionsMenu id={id} title={title} content={content} isAdmin={isAdmin(currUser.data)}/>
           }
         </div>
         <p className="mb-3 text-xl font-bold">{title}</p>

--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -7,7 +7,7 @@ import { api } from "~/utils/api";
 import { BlogPostActionsMenu } from "~/components/BlogPostActionsMenu";
 import { useSession } from "next-auth/react";
 import React from "react";
-import { isAdmin, isAuthed, isAuthor } from "~/components/util";
+import { hasPermissionToAccess, isAdmin } from "~/components/util";
 
 interface BlogPostProps extends React.ComponentProps<"div"> {
   id: string;
@@ -33,6 +33,7 @@ export const BlogPost: React.FC<BlogPostProps> = ({
 }) => {
   const currUser = api.user.currentUser.useQuery();
   const { status } = useSession();
+
   return (
     <div
       className="bg-base-150 card w-full rounded-md shadow-md shadow-slate-300"
@@ -50,8 +51,7 @@ export const BlogPost: React.FC<BlogPostProps> = ({
             </div>
           </div>
           {
-            ((currUser.data !== null) && (currUser.data !== undefined)) &&
-            ((isAuthed(status) && isAuthor(currUser.data, author)) || (isAuthed(status) && isAdmin(currUser.data))) &&
+            hasPermissionToAccess(status, currUser.data, author) &&
               <BlogPostActionsMenu id={id} title={title} content={content} isAdmin={isAdmin(currUser.data)}/>
           }
         </div>

--- a/src/components/BlogPostInputModal.tsx
+++ b/src/components/BlogPostInputModal.tsx
@@ -23,7 +23,7 @@ export const BlogPostInputModal: React.FC<PropsWithChildren<{
                 contentLabel="Blog Post Input"
                 overlayClassName="fixed inset-0 z-20 bg-black/75"
                 ariaHideApp={process.env.NODE_ENV !== 'test'}
-                className="bg-white absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-11/12 rounded-md md:w-1/2"
+                className="bg-white absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-11/12 rounded-md md:w-1/2 z-40"
             >
                 <div className="w-full h-12 flex flex-row justify-between items-center border-b border-b-gray-200 pl-4 pr-4">
                     <div className="font-semibold">{action} Blog Post</div>

--- a/src/components/BlogPostViewer.tsx
+++ b/src/components/BlogPostViewer.tsx
@@ -29,9 +29,7 @@ export const BlogPostViewer: React.FC = () => {
       ),
     [blogPosts]
   );
-
   const { ref, inView } = useInView();
-
   useEffect(() => {
     if (inView) {
       void (async () => {
@@ -39,7 +37,6 @@ export const BlogPostViewer: React.FC = () => {
       })();
     }
   }, [inView, fetchNextPage]);
-
   return (
     <div className="w-full md:w-1/2 ">
       <div className="mb-6 flex w-full justify-end">
@@ -84,6 +81,8 @@ export const BlogPostViewer: React.FC = () => {
                   lastUpdated={updatedAt}
                   post={content}
                   posterAvatarUrl={image as string}
+                  content={content}
+                  author={userId}
                 />
               </>
             )

--- a/src/components/CommentModal.tsx
+++ b/src/components/CommentModal.tsx
@@ -7,6 +7,10 @@ import remarkSlug from "remark-slug";
 import type { Comment as CommentType, User } from "@prisma/client";
 import { timeAgo } from "~/utils/time";
 import { ProfilePicture } from "./ProfilePicture";
+import { BlogPostActionsMenu } from "~/components/BlogPostActionsMenu";
+import { api } from "~/utils/api";
+import { useSession } from "next-auth/react";
+import { isAdmin, isAuthed, isAuthor } from "~/components/util";
 
 type CommentEntry = CommentType & { user: User };
 
@@ -18,6 +22,8 @@ export interface CommentModalProps {
   post: string;
   posterAvatarUrl: string;
   comments: CommentEntry[];
+  content: string;
+  author: string;
 }
 
 export const CommentModal: React.FC<CommentModalProps> = ({
@@ -28,6 +34,8 @@ export const CommentModal: React.FC<CommentModalProps> = ({
   post,
   posterAvatarUrl,
   comments,
+  author,
+  content,
 }) => {
   const [input, setInput] = useState<string>("");
 
@@ -40,11 +48,12 @@ export const CommentModal: React.FC<CommentModalProps> = ({
   const handlePostButtonClick = () => {
     console.log(`User comment: ${input}`);
   };
-
+  const currUser = api.user.currentUser.useQuery();
+  const { status } = useSession();
   return (
     <>
       <input type="checkbox" id={`modal-${id}`} className="modal-toggle" />
-      <label htmlFor={`modal-${id}`} className="modal cursor-pointer">
+      <label htmlFor={`modal-${id}`} className="modal cursor-pointer z-10">
         <label
           className="card-body modal-box relative m-[-10px] w-11/12 max-w-5xl rounded-md"
           htmlFor=""
@@ -59,24 +68,11 @@ export const CommentModal: React.FC<CommentModalProps> = ({
                 <p className="text-sm text-slate-400">{timeAgo(lastUpdated)}</p>
               </div>
             </div>
-            <div className="self-center">
-              <div className="dropdown-left dropdown rounded-md shadow-slate-300">
-                <button>
-                  <MenuIcon />
-                </button>
-                <ul
-                  tabIndex={0}
-                  className="dropdown-content menu rounded-box w-52 bg-base-100 p-2 shadow"
-                >
-                  <li>
-                    <a>Edit</a>
-                  </li>
-                  <li>
-                    <a>Delete</a>
-                  </li>
-                </ul>
-              </div>
-            </div>
+            {
+              ((currUser.data !== null) && (currUser.data !== undefined)) &&
+              ((isAuthed(status) && isAuthor(currUser.data, author)) || (isAuthed(status) && isAdmin(currUser.data))) &&
+                <BlogPostActionsMenu id={id} title={title} content={content} isAdmin={isAdmin(currUser.data)}/>
+            }
           </div>
           <p className="mb-3 text-xl font-bold">{title}</p>
           <div className="prose max-w-none ">

--- a/src/components/CommentModal.tsx
+++ b/src/components/CommentModal.tsx
@@ -10,7 +10,7 @@ import { ProfilePicture } from "./ProfilePicture";
 import { BlogPostActionsMenu } from "~/components/BlogPostActionsMenu";
 import { api } from "~/utils/api";
 import { useSession } from "next-auth/react";
-import { isAdmin, isAuthed, isAuthor } from "~/components/util";
+import { hasPermissionToAccess, isAdmin } from "~/components/util";
 
 type CommentEntry = CommentType & { user: User };
 
@@ -69,8 +69,7 @@ export const CommentModal: React.FC<CommentModalProps> = ({
               </div>
             </div>
             {
-              ((currUser.data !== null) && (currUser.data !== undefined)) &&
-              ((isAuthed(status) && isAuthor(currUser.data, author)) || (isAuthed(status) && isAdmin(currUser.data))) &&
+              hasPermissionToAccess(status, currUser.data, author) &&
                 <BlogPostActionsMenu id={id} title={title} content={content} isAdmin={isAdmin(currUser.data)}/>
             }
           </div>

--- a/src/components/util.ts
+++ b/src/components/util.ts
@@ -1,0 +1,22 @@
+import type { User } from "@prisma/client";
+
+export const isAuthed = (status: string) => {
+  if (status === "authenticated") {
+    return true;
+  } else if (status === "unauthenticated") {
+    return false;
+  }
+}
+
+export const isAuthor = (currUserData: User, authorUserId: string) => {
+  if ((currUserData !== null) && (currUserData !== undefined)) {
+    return currUserData.id === authorUserId;
+  }
+}
+
+export const isAdmin = (currUserData: User) => {
+  if ((currUserData !== null) && (currUserData !== undefined)) {
+    return currUserData.role === "ADMIN";
+  }
+  return false;
+}

--- a/src/components/util.ts
+++ b/src/components/util.ts
@@ -1,6 +1,6 @@
 import type { User } from "@prisma/client";
 
-export const isAuthed = (status: string) => {
+const isAuthed = (status: string) => {
   if (status === "authenticated") {
     return true;
   } else if (status === "unauthenticated") {
@@ -8,15 +8,19 @@ export const isAuthed = (status: string) => {
   }
 }
 
-export const isAuthor = (currUserData: User, authorUserId: string) => {
+const isAuthor = (currUserData: User | null | undefined, authorUserId: string) => {
   if ((currUserData !== null) && (currUserData !== undefined)) {
     return currUserData.id === authorUserId;
   }
 }
 
-export const isAdmin = (currUserData: User) => {
+export const isAdmin = (currUserData: User | null | undefined) => {
   if ((currUserData !== null) && (currUserData !== undefined)) {
     return currUserData.role === "ADMIN";
   }
   return false;
+}
+
+export const hasPermissionToAccess = (status: string, currUserData: User | null | undefined, authorUserId: string) => {
+  return ((isAuthed(status) && isAuthor(currUserData, authorUserId)) || (isAuthed(status) && isAdmin(currUserData)))
 }


### PR DESCRIPTION
## Context
Add the update/delete functionality when opening a blog post via the Comment modal

## Describe your changes
Previously only implemented the update/delete functionality when looking at blog posts from the collective feed. This PR adds the same functionality into the blog post when viewed after opening the comments modal. Refactored shared logic into a `util.ts` file. 

There is a non-breaking UI-related bug as a result of this change that I'm unsure how to address right now:
Steps to reproduce:
1) Create a blog post
2) Open the blog post in modal view by clicking on the "Comments" button
3) Click the 3-dots menu and select "Delete"; confirm the deletion
4) Observe: the modal view does not close and return user to the collective feed; instead, the modal view presents the contents of the next blog post on the feed

Since this is non-breaking, I would like feedback on whether it's okay to merge this still for now, so the Edit and Delete buttons on the comment modal are functional for the MVP.

***EDIT: will merge these changes in for MVP, the bug is captured in a [ticket](https://continuus.atlassian.net/browse/CON-111) for fixing later.


## Issue ticket number and link
https://continuus.atlassian.net/browse/CON-11

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] I verified that my code will compile by running `npm run build` 
- [x] I have run `npm run lint` and fixed linting errors
