### PR TITLE
refresh after delete to close comment modal

### DIFF
--- a/src/components/BlogPostActionsMenu.tsx
+++ b/src/components/BlogPostActionsMenu.tsx
@@ -2,7 +2,6 @@ import { MenuIcon } from "~/icons/Menu";
 import { UpdateBlogPostWidget } from "~/components/update-blog-post-widget/UpdateBlogPostWidget";
 import React from "react";
 import { DeleteBlogPostWidget } from "~/components/delete-blog-post-widget/DeleteBlogPostWidget";
-import { isAuthor } from "~/components/util";
 
 interface BlogPostActionsProps {
   id: string;

--- a/src/components/delete-blog-post-widget/DeleteBlogPostWidget.tsx
+++ b/src/components/delete-blog-post-widget/DeleteBlogPostWidget.tsx
@@ -10,27 +10,17 @@ interface DeleteBlogPostWidgetProps {
 }
 
 export const DeleteBlogPostWidget: React.FC<DeleteBlogPostWidgetProps> = ({ id }) => {
-  const utils = api.useContext();
-
-  const deleteBlogPostMutation = api.blogPost.delete.useMutation({
-    onSuccess(data, variables, context) {
-      return utils.blogPost.get.invalidate();
-    },
-  });
-
+  const deleteBlogPostMutation = api.blogPost.delete.useMutation();
   const [isModalOpen, setModalOpen] = useState(false);
   const [isSuccessful, setSuccessful] = useState(false);
 
   useEffect(() => {
     if (deleteBlogPostMutation.isSuccess) {
       setSuccessful(true);
-
       const timeoutId = setTimeout(() => {
         location.reload();
       }, 2000);
-
       return () => {
-        setSuccessful(false);
         clearTimeout(timeoutId);
       };
     }
@@ -45,7 +35,6 @@ export const DeleteBlogPostWidget: React.FC<DeleteBlogPostWidgetProps> = ({ id }
         onRequestClose={() => {
           setModalOpen(false);
         }}
-        closeDisabled={deleteBlogPostMutation.isLoading || isSuccessful}
       >
         {deleteBlogPostMutation.isLoading ? (
           <div className="flex h-96 w-full items-center justify-center">

--- a/src/components/delete-blog-post-widget/DeleteBlogPostWidget.tsx
+++ b/src/components/delete-blog-post-widget/DeleteBlogPostWidget.tsx
@@ -26,8 +26,7 @@ export const DeleteBlogPostWidget: React.FC<DeleteBlogPostWidgetProps> = ({ id }
       setSuccessful(true);
 
       const timeoutId = setTimeout(() => {
-        setModalOpen(false);
-        setSuccessful(false);
+        location.reload();
       }, 2000);
 
       return () => {

--- a/src/components/delete-blog-post-widget/DeleteBlogPostWidget.tsx
+++ b/src/components/delete-blog-post-widget/DeleteBlogPostWidget.tsx
@@ -35,6 +35,7 @@ export const DeleteBlogPostWidget: React.FC<DeleteBlogPostWidgetProps> = ({ id }
         onRequestClose={() => {
           setModalOpen(false);
         }}
+        closeDisabled={deleteBlogPostMutation.isLoading || isSuccessful}
       >
         {deleteBlogPostMutation.isLoading ? (
           <div className="flex h-96 w-full items-center justify-center">


### PR DESCRIPTION
## Context
When deleting a blog post from the comment modal, the user would not be redirected to the blog feed automatically; could cause user confusion.

## Describe your changes
Reload page on successful delete. There are probably cleaner ways to do this by altering state in parent components, but I think this is the simplest workaround for now.

## Issue ticket number and link
https://continuus.atlassian.net/browse/CON-111

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] I verified that my code will compile by running `npm run build` 
- [x] I have run `npm run lint` and fixed linting errors
