### PR TITLE
Make cleanup wait for tests to complete

### DIFF
--- a/.github/workflows/dev-qa-prod.yml
+++ b/.github/workflows/dev-qa-prod.yml
@@ -148,6 +148,5 @@ jobs:
     - name: 'Start Google Cloud Build trigger'
       run: |
         export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-        chmod +x ./scripts/wait-for-build
         gcloud artifacts docker images delete northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/${{ steps.vars.outputs.sha_short }}-test --delete-tags
 

--- a/.github/workflows/dev-qa-prod.yml
+++ b/.github/workflows/dev-qa-prod.yml
@@ -127,7 +127,7 @@ jobs:
   cleanup:
     name: Cleanup Test Artifacts
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [unit-test, integration-test, coverage-test]
     steps:
     - uses: actions/checkout@v3
     - id: 'auth'

--- a/.github/workflows/feature-workflow.yml
+++ b/.github/workflows/feature-workflow.yml
@@ -123,6 +123,5 @@ jobs:
     - name: 'Start Google Cloud Build trigger'
       run: |
         export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-        chmod +x ./scripts/wait-for-build
         gcloud artifacts docker images delete northamerica-northeast2-docker.pkg.dev/automatic-bot-376307/continuus/$(git rev-parse --short ${{ github.event.pull_request.head.sha }})-test --delete-tags
 


### PR DESCRIPTION
## Context
cleanup depended on just the build causing it to delete manifests before the tests could use them 

## Describe your changes
Updated cleanup to wait for all tests to run

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [X] I verified that my code will compile by running `npm run build` 
- [X] I have run `npm run lint` and fixed linting errors
